### PR TITLE
getUsers method to use GET method instead of POST

### DIFF
--- a/src/slack.js
+++ b/src/slack.js
@@ -84,7 +84,7 @@ class Slack {
 
                 const result = await request.get({ url, json: true });
 
-                if (_.isEmpty(result.members)) return reject(new Error('No users found, check token'));
+                if (_.isEmpty(result.members)) return reject(new Error('No users found.'));
 
                 this._users = result.members;
 

--- a/src/slack.js
+++ b/src/slack.js
@@ -82,7 +82,9 @@ class Slack {
                 const payload = this.getNormalizedPayload();
                 const url = this.getUrlWithPayload(SLACK_ENDPOINT_USERS_LIST, payload);
 
-                const result = await request.post({ url, json: true });
+                const result = await request.get({ url, json: true });
+
+                if (_.isEmpty(result.members)) return reject(new Error('No users found, check token'));
 
                 this._users = result.members;
 


### PR DESCRIPTION
Changed request type from post to get as it is preferred method anyways: https://api.slack.com/methods/users.list 